### PR TITLE
Reuse map marker image by caching them into a shared hash map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,20 +3,17 @@
 buildscript {
   repositories {
     jcenter()
+    google()
   }
   dependencies {
-    classpath 'com.android.tools.build:gradle:2.3.2'
+    classpath 'com.android.tools.build:gradle:3.3.1'
   }
 }
 
 allprojects {
   repositories {
-    mavenLocal()
+mavenLocal()
     jcenter()
-    maven {
-      // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
-      url "$rootDir/node_modules/react-native/android"
-    }
   }
 }
 

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -85,7 +85,6 @@ def enableProguardInReleaseBuilds = false
 
 android {
     compileSdkVersion 25
-    buildToolsVersion "25.0.3"
 
     defaultConfig {
         applicationId "com.airbnb.android.react.maps.example"
@@ -127,8 +126,8 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.51.+'
-    compile 'com.android.support:appcompat-v7:25.3.0'
-    compile 'com.android.support:support-annotations:25.3.0'
-    compile project(':react-native-maps-lib')
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.android.support:appcompat-v7:25.3.0'
+    implementation 'com.android.support:support-annotations:25.3.0'
+    implementation project(':react-native-maps-lib')
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon May 08 11:03:28 PDT 2017
+#Thu Feb 28 11:24:45 SGT 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.0-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip

--- a/lib/android/build.gradle
+++ b/lib/android/build.gradle
@@ -9,7 +9,6 @@ def DEFAULT_ANDROID_MAPS_UTILS_VERSION      = "0.5+"
 
 android {
   compileSdkVersion rootProject.hasProperty('compileSdkVersion') ? rootProject.compileSdkVersion : DEFAULT_COMPILE_SDK_VERSION
-  buildToolsVersion rootProject.hasProperty('buildToolsVersion') ? rootProject.buildToolsVersion : DEFAULT_BUILD_TOOLS_VERSION
 
   defaultConfig {
     minSdkVersion 16
@@ -43,7 +42,7 @@ dependencies {
   def googlePlayServicesVersion = rootProject.hasProperty('googlePlayServicesVersion')  ? rootProject.googlePlayServicesVersion : DEFAULT_GOOGLE_PLAY_SERVICES_VERSION
   def androidMapsUtilsVersion   = rootProject.hasProperty('androidMapsUtilsVersion')    ? rootProject.androidMapsUtilsVersion   : DEFAULT_ANDROID_MAPS_UTILS_VERSION
 
-  compileOnly "com.facebook.react:react-native:+"
+  implementation "com.facebook.react:react-native:+"
   implementation "com.google.android.gms:play-services-base:$googlePlayServicesVersion"
   implementation "com.google.android.gms:play-services-maps:$googlePlayServicesVersion"
   implementation "com.google.maps.android:android-maps-utils:$androidMapsUtilsVersion"

--- a/lib/android/src/main/AndroidManifest.xml
+++ b/lib/android/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.airbnb.android.react.maps" >
-    <uses-sdk android:minSdkVersion="16" />
+    <uses-sdk/>
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 </manifest>

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -19,7 +19,6 @@ import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapStyleOptions;
-import com.google.maps.android.data.kml.KmlLayer;
 
 import java.util.Map;
 
@@ -47,12 +46,20 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   );
 
   private final ReactApplicationContext appContext;
+  private AirMapMarkerManager markerManager = null;
 
   protected GoogleMapOptions googleMapOptions;
 
   public AirMapManager(ReactApplicationContext context) {
     this.appContext = context;
     this.googleMapOptions = new GoogleMapOptions();
+  }
+
+  public AirMapMarkerManager getMarkerManager() {
+    return this.markerManager;
+  }
+  public void setMarkerManager(AirMapMarkerManager markerManager) {
+    this.markerManager = markerManager;
   }
 
   @Override

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -125,7 +125,8 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
      */
     public synchronized void updateIcon(BitmapDescriptor bitmapDescriptor, Bitmap bitmap) {
       this.iconBitmapDescriptor = bitmapDescriptor;
-      this.bitmap = bitmap;
+      // we need this bitmap to be mutable in order for canvas to draw on it
+      this.bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
       List<WeakReference<AirMapMarker>> newArray = new ArrayList<>();
       for (WeakReference<AirMapMarker> weakMarker : markers) {
         AirMapMarker marker = weakMarker.get();

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -175,15 +175,24 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
      * @return
      */
     private BitmapDescriptor drawTextOnBitmap(String text, Bitmap bitmap) {
-      Bitmap newBitmap = Bitmap.createBitmap(bitmap);
-      Canvas canvas = new Canvas(newBitmap);
-      Paint paint = new Paint();
-      paint.setColor(Color.WHITE);
-      paint.setTextSize(30);
-      paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
-      int height = bitmap.getHeight();
-      canvas.drawText(text, 15, height / 2, paint);
-      return BitmapDescriptorFactory.fromBitmap(newBitmap);
+      if (text != null && text.length() > 0) {
+        Bitmap newBitmap = Bitmap.createBitmap(bitmap);
+        Canvas canvas = new Canvas(newBitmap);
+        Paint paint = new Paint();
+        paint.setColor(Color.WHITE);
+        paint.setTextSize(30);
+        paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
+        // calculate the margin left value
+        float textWidth = paint.measureText(text);
+        float bitmapWidth = Math.max(bitmap.getWidth(), 0);
+        // it is ok to be negative here.
+        float leftMargin = (bitmapWidth - textWidth) / 2;
+        int height = bitmap.getHeight();
+        canvas.drawText(text, leftMargin, height / 2, paint);
+        return BitmapDescriptorFactory.fromBitmap(newBitmap);
+      } else {
+        return BitmapDescriptorFactory.fromBitmap(bitmap);
+      }
     }
 
     /**

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -180,11 +180,19 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
         Canvas canvas = new Canvas(newBitmap);
         Paint paint = new Paint();
         paint.setColor(Color.WHITE);
-        paint.setTextSize(30);
         paint.setTypeface(Typeface.create(Typeface.DEFAULT, Typeface.BOLD));
-        // calculate the margin left value
+        // calculate the margin left value,
+        // and adjust the text size to make it fit into the marker, as much as possible
+        float textSize = 30;
+        paint.setTextSize(textSize);
         float textWidth = paint.measureText(text);
         float bitmapWidth = Math.max(bitmap.getWidth(), 0);
+        while (bitmapWidth < textWidth && textSize >= 15) {
+          // reducing the text size until it is 15 point or text can be fit into the marker.
+          textSize -= 3;
+          paint.setTextSize(textSize);
+          textWidth = paint.measureText(text);
+        }
         // it is ok to be negative here.
         float leftMargin = (bitmapWidth - textWidth) / 2;
         int height = bitmap.getHeight();

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -178,6 +178,7 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
     private BitmapDescriptor drawTextOnBitmap(String text, Bitmap bitmap) {
       if (text != null && text.length() > 0) {
         Bitmap newBitmap = Bitmap.createBitmap(bitmap);
+        newBitmap = newBitmap.copy(Bitmap.Config.ARGB_8888, true);
         Canvas canvas = new Canvas(newBitmap);
         Paint paint = new Paint();
         paint.setColor(Color.WHITE);

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -970,7 +970,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         options.title(title);
         options.snippet(snippet);
 
-        AirMapMarker marker = new AirMapMarker(context, options);
+        AirMapMarker marker = new AirMapMarker(context, options, this.manager.getMarkerManager());
 
         if (placemark.getInlineStyle() != null
             && placemark.getInlineStyle().getIconUrl() != null) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -41,6 +41,7 @@ public class MapsPackage implements ReactPackage {
     AirMapUrlTileManager urlTileManager = new AirMapUrlTileManager(reactContext);
     AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
     AirMapOverlayManager overlayManager = new AirMapOverlayManager(reactContext);
+    mapManager.setMarkerManager(annotationManager);
 
     return Arrays.<ViewManager>asList(
         calloutManager,

--- a/lib/components/MapMarker.js
+++ b/lib/components/MapMarker.js
@@ -48,6 +48,14 @@ const propTypes = {
   description: PropTypes.string,
 
   /**
+   * Put a simple text on the marker image.
+   * This is only used if the <Marker /> component has no children.
+   *
+   * @platform android
+   */
+  markerText: PropTypes.string,
+
+  /**
    * A custom image to be used as the marker's icon. Only local image resources are allowed to be
    * used.
    */


### PR DESCRIPTION
using image uri as key.

When there are thousands of markers in the map that uses only a few of image icons, the marker object would takes too much memories, and depends on the image size, it may crash because of out of memory exception.

This fix is just to cache the generated bitmap and bitmap descriptor into a concurrent hash map, so that when the image is needed, we can retrieve them from the map. So the memory consumption is only subject to the different number of images uri used.