### PR TITLE
Master: Share image for markers to reduce Android memory usage.

### DIFF
--- a/example/App.js
+++ b/example/App.js
@@ -45,6 +45,7 @@ import AnimatedNavigation from './examples/AnimatedNavigation';
 import OnPoiClick from './examples/OnPoiClick';
 import IndoorMap from './examples/IndoorMap';
 import CameraControl from './examples/CameraControl';
+import MassiveCustomMarkers from './examples/MassiveCustomMarkers';
 
 const IOS = Platform.OS === 'ios';
 const ANDROID = Platform.OS === 'android';
@@ -169,6 +170,7 @@ export default class App extends React.Component<Props> {
       [OnPoiClick, 'On Poi Click', true],
       [IndoorMap, 'Indoor Map', true],
       [CameraControl, 'CameraControl', true],
+      [MassiveCustomMarkers, 'MassiveCustomMarkers', true],
     ]
     // Filter out examples that are not yet supported for Google Maps on iOS.
     .filter(example => ANDROID || (IOS && (example[2] || !this.state.useGoogleMaps)))

--- a/example/examples/MassiveCustomMarkers.js
+++ b/example/examples/MassiveCustomMarkers.js
@@ -1,0 +1,131 @@
+import React from 'react';
+import {
+  StyleSheet,
+  View,
+  Text,
+  Dimensions,
+  TouchableOpacity,
+} from 'react-native';
+
+import MapView, { Marker, ProviderPropType } from 'react-native-maps';
+import flagPinkImg from './assets/flag-pink.png';
+
+const { width, height } = Dimensions.get('window');
+
+const ASPECT_RATIO = width / height;
+const LATITUDE = 37.78825;
+const LONGITUDE = -122.4324;
+const LATITUDE_DELTA = 0.0922;
+const LONGITUDE_DELTA = LATITUDE_DELTA * ASPECT_RATIO;
+let id = 0;
+
+class MassiveCustomMarkers extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      region: {
+        latitude: LATITUDE,
+        longitude: LONGITUDE,
+        latitudeDelta: LATITUDE_DELTA,
+        longitudeDelta: LONGITUDE_DELTA,
+      },
+      markers: [],
+    };
+
+    this.onMapPress = this.onMapPress.bind(this);
+  }
+
+  generateMarkers(fromCoordinate) {
+    const result = [];
+    const { latitude, longitude } = fromCoordinate;
+    for (let i = 0; i < 100; i++) {
+      const newMarker = {
+        coordinate: {
+          latitude: latitude + (0.001 * i),
+          longitude: longitude + (0.001 * i),
+        },
+        key: `foo${id++}`,
+      };
+      result.push(newMarker);
+    }
+    return result;
+  }
+
+  onMapPress(e) {
+    this.setState({
+      markers: [
+        ...this.state.markers,
+        ...this.generateMarkers(e.nativeEvent.coordinate),
+      ],
+    });
+  }
+
+  render() {
+    return (
+      <View style={styles.container}>
+        <MapView
+          provider={this.props.provider}
+          style={styles.map}
+          initialRegion={this.state.region}
+          onPress={this.onMapPress}
+        >
+          {this.state.markers.map(marker => (
+            <Marker
+              title={marker.key}
+              image={flagPinkImg}
+              key={marker.key}
+              coordinate={marker.coordinate}
+            />
+          ))}
+        </MapView>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            onPress={() => this.setState({ markers: [] })}
+            style={styles.bubble}
+          >
+            <Text>Tap to create 100 markers</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    );
+  }
+}
+
+MassiveCustomMarkers.propTypes = {
+  provider: ProviderPropType,
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    justifyContent: 'flex-end',
+    alignItems: 'center',
+  },
+  map: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  bubble: {
+    backgroundColor: 'rgba(255,255,255,0.7)',
+    paddingHorizontal: 18,
+    paddingVertical: 12,
+    borderRadius: 20,
+  },
+  latlng: {
+    width: 200,
+    alignItems: 'stretch',
+  },
+  button: {
+    width: 80,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+    marginHorizontal: 10,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    marginVertical: 20,
+    backgroundColor: 'transparent',
+  },
+});
+
+export default MassiveCustomMarkers;

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapManager.java
@@ -19,10 +19,9 @@ import com.google.android.gms.maps.GoogleMapOptions;
 import com.google.android.gms.maps.model.LatLng;
 import com.google.android.gms.maps.model.LatLngBounds;
 import com.google.android.gms.maps.model.MapStyleOptions;
-import com.google.maps.android.data.kml.KmlLayer;
 
-import java.util.Map;
 import java.util.HashMap;
+import java.util.Map;
 
 import javax.annotation.Nullable;
 
@@ -52,12 +51,20 @@ public class AirMapManager extends ViewGroupManager<AirMapView> {
   );
 
   private final ReactApplicationContext appContext;
+  private AirMapMarkerManager markerManager;
 
   protected GoogleMapOptions googleMapOptions;
 
   public AirMapManager(ReactApplicationContext context) {
     this.appContext = context;
     this.googleMapOptions = new GoogleMapOptions();
+  }
+
+  public AirMapMarkerManager getMarkerManager() {
+    return this.markerManager;
+  }
+  public void setMarkerManager(AirMapMarkerManager markerManager) {
+    this.markerManager = markerManager;
   }
 
   @Override

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarker.java
@@ -79,6 +79,8 @@ public class AirMapMarker extends AirMapFeature {
   private boolean hasViewChanges = true;
 
   private boolean hasCustomMarkerView = false;
+  private final AirMapMarkerManager markerManager;
+  private String imageUri;
 
   private final DraweeHolder<?> logoHolder;
   private DataSource<CloseableReference<CloseableImage>> dataSource;
@@ -110,20 +112,26 @@ public class AirMapMarker extends AirMapFeature {
               CloseableReference.closeSafely(imageReference);
             }
           }
+          if (AirMapMarker.this.markerManager != null && AirMapMarker.this.imageUri != null) {
+            AirMapMarker.this.markerManager.getSharedIcon(AirMapMarker.this.imageUri)
+                .updateIcon(iconBitmapDescriptor, iconBitmap);
+          }
           update(true);
         }
       };
 
-  public AirMapMarker(Context context) {
+  public AirMapMarker(Context context, AirMapMarkerManager markerManager) {
     super(context);
     this.context = context;
+    this.markerManager = markerManager;
     logoHolder = DraweeHolder.create(createDraweeHierarchy(), context);
     logoHolder.onAttach();
   }
 
-  public AirMapMarker(Context context, MarkerOptions options) {
+  public AirMapMarker(Context context, MarkerOptions options, AirMapMarkerManager markerManager) {
     super(context);
     this.context = context;
+    this.markerManager = markerManager;
     logoHolder = DraweeHolder.create(createDraweeHierarchy(), context);
     logoHolder.onAttach();
 
@@ -316,6 +324,31 @@ public class AirMapMarker extends AirMapFeature {
   public void setImage(String uri) {
     hasViewChanges = true;
 
+    boolean shouldLoadImage = true;
+
+    if (this.markerManager != null) {
+      // remove marker from previous shared icon if needed, to avoid future updates from it.
+      // remove the shared icon completely if no markers on it as well.
+      // this is to avoid memory leak due to orphan bitmaps.
+      //
+      // However in case where client want to update all markers from icon A to icon B
+      // and after some time to update back from icon B to icon A
+      // it may be better to keep it though. We assume that is rare.
+      if (this.imageUri != null) {
+        this.markerManager.getSharedIcon(this.imageUri).removeMarker(this);
+        this.markerManager.removeSharedIconIfEmpty(this.imageUri);
+      }
+      if (uri != null) {
+        // listening for marker bitmap descriptor update, as well as check whether to load the image.
+        AirMapMarkerManager.AirMapMarkerSharedIcon sharedIcon = this.markerManager.getSharedIcon(uri);
+        sharedIcon.addMarker(this);
+        shouldLoadImage = sharedIcon.shouldLoadImage();
+      }
+    }
+
+    this.imageUri = uri;
+    if (!shouldLoadImage) {return;}
+
     if (uri == null) {
       iconBitmapDescriptor = null;
       update(true);
@@ -346,8 +379,22 @@ public class AirMapMarker extends AirMapFeature {
               drawable.draw(canvas);
           }
       }
+      if (this.markerManager != null && uri != null) {
+        this.markerManager.getSharedIcon(uri).updateIcon(iconBitmapDescriptor, iconBitmap);
+      }
       update(true);
     }
+  }
+
+  public void setIconBitmapDescriptor(BitmapDescriptor bitmapDescriptor, Bitmap bitmap) {
+    this.iconBitmapDescriptor = bitmapDescriptor;
+    this.iconBitmap = bitmap;
+    this.hasViewChanges = true;
+    this.update(true);
+  }
+
+  public void setIconBitmap(Bitmap bitmap) {
+    this.iconBitmap = bitmap;
   }
 
   public MarkerOptions getMarkerOptions() {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapMarkerManager.java
@@ -1,5 +1,6 @@
 package com.airbnb.android.react.maps;
 
+import android.graphics.Bitmap;
 import android.graphics.Color;
 import android.view.View;
 
@@ -11,10 +12,13 @@ import com.facebook.react.uimanager.ThemedReactContext;
 import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
 import com.google.android.gms.maps.model.Marker;
+import com.google.android.gms.maps.model.BitmapDescriptor;
 import com.google.android.gms.maps.model.LatLng;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.WeakHashMap;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.annotation.Nullable;
 
@@ -24,6 +28,128 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
   private static final int HIDE_INFO_WINDOW = 2;
   private static final int ANIMATE_MARKER_TO_COORDINATE = 3;
   private static final int REDRAW = 4;
+
+  public static class AirMapMarkerSharedIcon {
+    private BitmapDescriptor iconBitmapDescriptor;
+    private Bitmap bitmap;
+    private Map<AirMapMarker, Boolean> markers;
+    private boolean loadImageStarted;
+
+    public AirMapMarkerSharedIcon(){
+      this.markers = new WeakHashMap<>();
+      this.loadImageStarted = false;
+    }
+
+    /**
+     * check whether the load image process started.
+     * caller AirMapMarker will only need to load it when this returns true.
+     *
+     * @return true if it is not started, false otherwise.
+     */
+    public synchronized boolean shouldLoadImage(){
+      if (!this.loadImageStarted) {
+        this.loadImageStarted = true;
+        return true;
+      }
+      return false;
+    }
+
+    /**
+     * subscribe icon update for given marker.
+     *
+     * The marker is wrapped in weakReference, so no need to remove it explicitly.
+     *
+     * @param marker
+     */
+    public synchronized void addMarker(AirMapMarker marker) {
+      this.markers.put(marker, true);
+      if (this.iconBitmapDescriptor != null) {
+        marker.setIconBitmapDescriptor(this.iconBitmapDescriptor, this.bitmap);
+      }
+    }
+
+    /**
+     * Remove marker from this shared icon.
+     *
+     * Marker will only need to call it when the marker receives a different marker image uri.
+     *
+     * @param marker
+     */
+    public synchronized void removeMarker(AirMapMarker marker) {
+      this.markers.remove(marker);
+    }
+
+    /**
+     * check if there is markers still listening on this icon.
+     * when there are not markers listen on it, we can remove it.
+     *
+     * @return true if there is, false otherwise
+     */
+    public synchronized boolean hasMarker(){
+      return this.markers.isEmpty();
+    }
+
+    /**
+     * Update the bitmap descriptor and bitmap for the image uri.
+     * And notify all subscribers about the update.
+     *
+     * @param bitmapDescriptor
+     * @param bitmap
+     */
+    public synchronized void updateIcon(BitmapDescriptor bitmapDescriptor, Bitmap bitmap) {
+
+      this.iconBitmapDescriptor = bitmapDescriptor;
+      this.bitmap = bitmap.copy(Bitmap.Config.ARGB_8888, true);
+
+      if (this.markers.isEmpty()) {
+        return;
+      }
+
+      for (Map.Entry<AirMapMarker, Boolean> markerEntry: markers.entrySet()) {
+        if (markerEntry.getKey() != null) {
+          markerEntry.getKey().setIconBitmapDescriptor(bitmapDescriptor, bitmap);
+        }
+      }
+    }
+  }
+
+  private Map<String, AirMapMarkerSharedIcon> sharedIcons = new ConcurrentHashMap<>();
+
+  /**
+   * get the shared icon object, if not existed, create a new one and store it.
+   *
+   * @param uri
+   * @return the icon object for the given uri.
+   */
+  public AirMapMarkerSharedIcon getSharedIcon(String uri) {
+    AirMapMarkerSharedIcon icon = this.sharedIcons.get(uri);
+    if (icon == null) {
+      synchronized (this) {
+        if((icon = this.sharedIcons.get(uri)) == null) {
+          icon = new AirMapMarkerSharedIcon();
+          this.sharedIcons.put(uri, icon);
+        }
+      }
+    }
+    return icon;
+  }
+
+  /**
+   * Remove the share icon object from our sharedIcons map when no markers are listening for it.
+   *
+   * @param uri
+   */
+  public void removeSharedIconIfEmpty(String uri) {
+    AirMapMarkerSharedIcon icon = this.sharedIcons.get(uri);
+    if (icon == null) {return;}
+    if (!icon.hasMarker()) {
+      synchronized (this) {
+        if((icon = this.sharedIcons.get(uri)) != null && !icon.hasMarker()) {
+          this.sharedIcons.remove(uri);
+        }
+      }
+    }
+  }
 
   public AirMapMarkerManager() {
   }
@@ -35,7 +161,7 @@ public class AirMapMarkerManager extends ViewGroupManager<AirMapMarker> {
 
   @Override
   public AirMapMarker createViewInstance(ThemedReactContext context) {
-    return new AirMapMarker(context);
+    return new AirMapMarker(context, this);
   }
 
   @ReactProp(name = "coordinate")

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/AirMapView.java
@@ -1110,7 +1110,7 @@ public class AirMapView extends MapView implements GoogleMap.InfoWindowAdapter,
         options.title(title);
         options.snippet(snippet);
 
-        AirMapMarker marker = new AirMapMarker(context, options);
+        AirMapMarker marker = new AirMapMarker(context, options, this.manager.getMarkerManager());
 
         if (placemark.getInlineStyle() != null
             && placemark.getInlineStyle().getIconUrl() != null) {

--- a/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
+++ b/lib/android/src/main/java/com/airbnb/android/react/maps/MapsPackage.java
@@ -41,6 +41,7 @@ public class MapsPackage implements ReactPackage {
     AirMapUrlTileManager urlTileManager = new AirMapUrlTileManager(reactContext);
     AirMapLocalTileManager localTileManager = new AirMapLocalTileManager(reactContext);
     AirMapOverlayManager overlayManager = new AirMapOverlayManager(reactContext);
+    mapManager.setMarkerManager(annotationManager);
 
     return Arrays.<ViewManager>asList(
         calloutManager,


### PR DESCRIPTION
<!--
PLEASE DON'T DELETE THIS TEMPLATE UNTIL YOU HAVE READ THE FIRST SECTION.

**What happens if you SKIP this step?**

Your pull request will NOT be evaluated!

PLEASE NOTE THAT PRs WITHOUT THE TEMPLATE IN PLACE WILL BE CLOSED RIGHT FROM THE START.

Thanks for helping us help you!
-->

### Does any other open PR do the same thing?

<!--
**Please keep in mind that we apply the FIFO rule for PRs, so if your PR comes after an existing one and there is no compelling reason to merge it instead of the existing one it will be discarded!**

If another PR exists that has similar scope to yours, please specify why you opened yours.
This could be one of the following (but not limited to)

 - the previous PR is stalled, as it's really old and the author didn't continue working on it
 - there are conflicts with the `master` branch and the author didn't fix them
 - the PR doesn't apply anymore (please specify why)
 - my PR is better (please specify why)
 -->

Looks No.

### What issue is this PR fixing?

Android app's memory usage climbs high when there are thousands of markers on the map, even though most of the markers uses same image and the images are only around 1KB.

This update is to use a shared image icon for markers when they share the same image URI, instead of loading and creating bitmap within each marker, which uses more memory in case we have a lot of them.

### How did you test this PR?

<!--
Please let us know how you have verified that your changes work.

Ideally, your PR should contain a step-by-step test plan, so that reviewers can easily verify your changes.

Your PR will have much better chances of being merged if it is straightforward to verify.

Some questions you might want to think about:

- Which platform (eg. Android/iOS) & Maps API (eg. Google/Apple) does this change affect, if any?
- Did you test this on a real device, or in a simulator?
- Are there any platforms you were not able to test?
-->

Ideally you should test it with an app that contains a lot of custom markers that shared a small image pool.

To make it simple, we have also create a new page in example app, named "MassiveCustomMarker", which will place 100 custom markers on tap on the map. It is added on the first commit of this PR, so you can check it out and run the example app. Open android studio profile and watch the memory usage while placing more markers on the map.

Then you can checkout the second commit and test it again. Check the memory usage difference.

<!--
Thanks for your contribution :)
-->
